### PR TITLE
Add a Utils.isDataUrl method to fix base64 images on Layer

### DIFF
--- a/framer/Utils.coffee
+++ b/framer/Utils.coffee
@@ -352,6 +352,9 @@ Utils.isMobile = ->
 Utils.isFileUrl = (url) ->
 	return _.startsWith(url, "file://")
 
+Utils.isDataUrl = (url) ->
+	return _.startsWith(url, "data:")
+
 Utils.isRelativeUrl = (url) ->
 	!/^([a-zA-Z]{1,8}:\/\/).*$/.test(url)
 
@@ -365,6 +368,7 @@ Utils.isLocalUrl = (url) ->
 
 Utils.isLocalAssetUrl = (url, baseUrl) ->
 	baseUrl ?= window.location.href
+	return false if Utils.isDataUrl(url)
 	return true if Utils.isLocalUrl(url)
 	return true if Utils.isRelativeUrl(url) and Utils.isLocalUrl(baseUrl)
 	return false

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -256,6 +256,25 @@ describe "Layer", ->
 			#layer.computedStyle()["background-size"].should.equal "cover"
 			#layer.computedStyle()["background-repeat"].should.equal "no-repeat"
 
+					
+		it "should not append nocache to a base64 encoded image", ->
+
+			prefix = "../"
+			imagePath = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEwAAABMBAMAAAA1uUwYAAAAAXNSR0IArs4c6QAAABVQTFRFKK/6LFj/g9n/lNf9lqz/wez/////Ke+vpgAAAK1JREFUSMft1sENhDAMBdFIrmBboAjuaWFrsNN/CRwAgUPsTAH556c5WVFKQyuLLYbZf/MLmDHW5yJmjHW5kBljPhczY8zlEmaMvXMZM8ZeuZQZY08uZzZh5dqen+XNhLFBbsiEsW9uzISxTy5gwlifi5gw1uVCJoz5XMyEMZdLmASs/s5NnkFl7M7NmDJ25aZMGTtzc6aMtcqYMtYqY8pYq4wpY60ypuvnsNizA+E6656TNMZlAAAAAElFTkSuQmCC"
+			fullPath = prefix + imagePath
+			layer = new Layer
+
+			layer.image = fullPath
+			layer.image.should.equal fullPath
+
+			image = layer.props.image
+			layer.props.image.should.equal fullPath
+
+			layer.style["background-image"].indexOf(imagePath).should.not.equal(-1)
+			layer.style["background-image"].indexOf("data:").should.not.equal(-1)
+			layer.style["background-image"].indexOf("?nocache=").should.equal(-1)
+
+
 		it "should cancel loading when setting image to null", (done) ->
 			prefix = "../"
 			imagePath = "static/test.png"

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -259,18 +259,16 @@ describe "Layer", ->
 					
 		it "should not append nocache to a base64 encoded image", ->
 
-			prefix = "../"
-			imagePath = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEwAAABMBAMAAAA1uUwYAAAAAXNSR0IArs4c6QAAABVQTFRFKK/6LFj/g9n/lNf9lqz/wez/////Ke+vpgAAAK1JREFUSMft1sENhDAMBdFIrmBboAjuaWFrsNN/CRwAgUPsTAH556c5WVFKQyuLLYbZf/MLmDHW5yJmjHW5kBljPhczY8zlEmaMvXMZM8ZeuZQZY08uZzZh5dqen+XNhLFBbsiEsW9uzISxTy5gwlifi5gw1uVCJoz5XMyEMZdLmASs/s5NnkFl7M7NmDJ25aZMGTtzc6aMtcqYMtYqY8pYq4wpY60ypuvnsNizA+E6656TNMZlAAAAAElFTkSuQmCC"
-			fullPath = prefix + imagePath
+			fullPath = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEwAAABMBAMAAAA1uUwYAAAAAXNSR0IArs4c6QAAABVQTFRFKK/6LFj/g9n/lNf9lqz/wez/////Ke+vpgAAAK1JREFUSMft1sENhDAMBdFIrmBboAjuaWFrsNN/CRwAgUPsTAH556c5WVFKQyuLLYbZf/MLmDHW5yJmjHW5kBljPhczY8zlEmaMvXMZM8ZeuZQZY08uZzZh5dqen+XNhLFBbsiEsW9uzISxTy5gwlifi5gw1uVCJoz5XMyEMZdLmASs/s5NnkFl7M7NmDJ25aZMGTtzc6aMtcqYMtYqY8pYq4wpY60ypuvnsNizA+E6656TNMZlAAAAAElFTkSuQmCC"
 			layer = new Layer
 
 			layer.image = fullPath
 			layer.image.should.equal fullPath
 
 			image = layer.props.image
-			layer.props.image.should.equal fullPath
+			image.should.equal fullPath
 
-			layer.style["background-image"].indexOf(imagePath).should.not.equal(-1)
+			layer.style["background-image"].indexOf(fullPath).should.not.equal(-1)
 			layer.style["background-image"].indexOf("data:").should.not.equal(-1)
 			layer.style["background-image"].indexOf("?nocache=").should.equal(-1)
 

--- a/test/tests/UtilsTest.coffee
+++ b/test/tests/UtilsTest.coffee
@@ -401,6 +401,15 @@ describe "Utils", ->
 			Utils.isFileUrl("file:///Users/koen/Desktop/index.html").should.equal(true)
 			Utils.isFileUrl("http://apple.com/index.html").should.equal(false)
 			Utils.isFileUrl("https://apple.com/index.html").should.equal(false)
+			
+	describe "isDataUrl", ->
+		it "should work", ->
+			dataUrlGif = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+			dataUrlPng = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QAAAAAAAD5Q7t/AAAACXBIWXMAAAsSAAALEgHS3X78AAAADUlEQVQI12P4z8DwHwAFAAH/cpxSZwAAAABJRU5ErkJggg=="
+			Utils.isDataUrl(dataUrlGif).should.equal(true)
+			Utils.isDataUrl(dataUrlPng).should.equal(true)
+			Utils.isDataUrl("file:///Users/koen/Desktop/foo.gif").should.equal(false)
+			Utils.isDataUrl("http://data.com/1x1.png").should.equal(false)
 
 	describe "isRelativeUrl", ->
 		it "should work", ->

--- a/test/tests/UtilsTest.coffee
+++ b/test/tests/UtilsTest.coffee
@@ -431,9 +431,11 @@ describe "Utils", ->
 
 	describe "isLocalAssetUrl", ->
 		it "should work", ->
+			dataUrl = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
 			Utils.isLocalAssetUrl("Desktop/index.html", "http://localhost/index.html").should.equal(true)
 			Utils.isLocalAssetUrl("/Desktop/index.html", "http://localhost/index.html").should.equal(true)
 			Utils.isLocalAssetUrl("Desktop/index.html", "http://127.0.0.1/index.html").should.equal(true)
 			Utils.isLocalAssetUrl("Desktop/index.html", "http://apple.com/index.html").should.equal(false)
 			Utils.isLocalAssetUrl("file:///Desktop/index.html", "http://apple.com/index.html").should.equal(true)
 			Utils.isLocalAssetUrl("http://apple.com/index.html", "http://127.0.0.1/index.html").should.equal(false)
+			Utils.isLocalAssetUrl("Desktop/index.html", dataUrl).should.equal(false)


### PR DESCRIPTION
Images on layers will set a ?nocache=.... on the file which breaks base64 encoded images. We need Utils.isLocalAssetUrl check to return false so that the query string isn't added. This update does exactly this.
